### PR TITLE
Kernel changes + New APIs

### DIFF
--- a/bin/init.lua
+++ b/bin/init.lua
@@ -48,4 +48,5 @@ end
 
 printStatus("Loading Video RAM..")
 vram.setViewport(105, 33)
-printStatus("Size: " .. vram.getSize())
+printStatus("VRAM Size: " .. vram.getSize())
+printStatus(filesystem.exists("/dev/hda/init.lua"))

--- a/bin/init.lua
+++ b/bin/init.lua
@@ -17,6 +17,7 @@ function printError(...)
     printStatus(...)
 end
 filesystem.mount("/", component.proxy(computer.getBootAddress()))
+lib.mount()
 printStatus([[ (o<
 //\
 V_/]])

--- a/bin/init.lua
+++ b/bin/init.lua
@@ -42,7 +42,7 @@ printStatus("Boot drive space usage: "..fs(bootDrive, "spaceUsed").."/"..fs(boot
 printStatus("Memory: "..computer.freeMemory().."/"..computer.totalMemory().." bytes available")
 
 printStatus("Drives:")
-for k, v in pairs(filesystem.getDrives()) do
+for k, v in pairs(filesystem.getDrives(true)) do -- also auto-mount drives to dev/hd_
 	printStatus(v)
 end
 

--- a/bin/init.lua
+++ b/bin/init.lua
@@ -1,5 +1,6 @@
 -- Init version
 _INITVER = "1.0"
+local filesystem = load(readFile(computer.getBootAddress(), "boot/kernel_modules/filesystem.lua"), nil, nil, _G)() -- load filesystem API
 
 function printInfo(...)
     writeStatus("[ INFO ] ")
@@ -15,6 +16,7 @@ function printError(...)
     writeStatus("[ ERROR! ] ")
     printStatus(...)
 end
+filesystem.mount("/", component.proxy(computer.getBootAddress()))
 printStatus([[ (o<
 //\
 V_/]])

--- a/bin/init.lua
+++ b/bin/init.lua
@@ -1,7 +1,16 @@
 -- Init version
 _INITVER = "1.0"
-local filesystem = load(readFile(computer.getBootAddress(), "boot/kernel_modules/filesystem.lua"), nil, nil, _G)() -- load filesystem API
+local fslib, err = load(readFile(computer.getBootAddress(), "boot/kernel_modules/filesystem.lua"), "=filesystem.lua", nil, _G) -- load filesystem API
+local filesystem
 
+local vlib, arr = load(readFile(computer.getBootAddress(), "lib/vram.lua"), "=vram.lua", nil, _G) -- load Video RAM API
+local vram
+if fslib ~= nil then
+	filesystem = fslib()
+end
+if vlib ~= nil then
+	vram = vlib()
+end
 function printInfo(...)
     writeStatus("[ INFO ] ")
     printStatus(...)
@@ -16,8 +25,13 @@ function printError(...)
     writeStatus("[ ERROR! ] ")
     printStatus(...)
 end
+if err ~= nil then -- unable to load filesystem api
+	printError(err)
+end
+if arr ~= nil then
+	printError(err)
+end
 filesystem.mount("/", component.proxy(computer.getBootAddress()))
-lib.mount()
 printStatus([[ (o<
 //\
 V_/]])
@@ -27,3 +41,11 @@ printStatus("Init version: ".._INITVER)
 printStatus("Boot drive space usage: "..fs(bootDrive, "spaceUsed").."/"..fs(bootDrive, "spaceTotal").." bytes available")
 printStatus("Memory: "..computer.freeMemory().."/"..computer.totalMemory().." bytes available")
 
+printStatus("Drives:")
+for k, v in pairs(filesystem.getDrives()) do
+	printStatus(v)
+end
+
+printStatus("Loading Video RAM..")
+vram.setViewport(105, 33)
+printStatus("Size: " .. vram.getSize())

--- a/boot/kernel/OCLinux.lua
+++ b/boot/kernel/OCLinux.lua
@@ -88,6 +88,7 @@ function writeStatus(...)
 end
 
 -- A very low level filesystem controller
+-- that is now useless with "filesystem" API
 function fs(drive, op, arg, ...)
     return component.invoke(drive, op, arg, ...)
 end
@@ -105,7 +106,14 @@ function execInit(init)
     if fs(bootDrive, "exists", init) then
         printStatus("Init found!")
         initC = readFile(bootDrive, init)
-        load(initC, nil, nil, _G)()
+        local v, err = pcall(function()
+			load(initC, "=" .. init, nil, _G)()
+		end)
+		if not v then
+			gpuInvoke("setForeground", 0xFF0000) -- some unstandard way to do error
+			printStatus(err)
+			panic("An error occured during execution")
+		end
         return true
     else
         printStatus("Not here")

--- a/boot/kernel/OCLinux.lua
+++ b/boot/kernel/OCLinux.lua
@@ -94,9 +94,18 @@ function fs(drive, op, arg, ...)
 end
 
 function readFile(drive, file)
-    fileHandle = fs(drive, "open", file, "r")
-    fileSize = fs(drive, "size", file)
-    fileContent = fs(drive, "read", fileHandle, fileSize)
+    local fileHandle = fs(drive, "open", file, "r")
+    local fileSize = fs(drive, "size", file)
+    local fileContent = ""
+    local tmp = fileSize
+	local readed = ""
+    while true do
+		readed = fs(drive, "read", fileHandle, 2048)
+		if readed == nil then
+			break
+		end
+        fileContent = fileContent .. readed
+    end
     return fileContent
 end
 

--- a/boot/kernel_modules/filesystem.lua
+++ b/boot/kernel_modules/filesystem.lua
@@ -1,0 +1,32 @@
+-- Simple filesystem API with multiple mount points
+
+local filesystems = {}
+local lib = {}
+
+local function hasMountPoint(path)
+    for k, v in pairs(filesystems) do
+        local p = v[1]
+        if p == path then -- if is same path
+            return true
+        end
+    end
+    return false
+end
+
+function lib.mount(path, fs)
+    if hasMountPoint(path) then
+		error(path .. " is arleady mounted")
+	end
+    table.insert(filesystems, {path, fs})
+end
+
+function lib.umount(path)
+    for k, v in pairs(filesystems) do
+        local p = v[1]
+        if p == path then -- if is same path
+            table.remove(filesystems, k)
+        end
+    end
+end
+
+return lib

--- a/boot/kernel_modules/filesystem.lua
+++ b/boot/kernel_modules/filesystem.lua
@@ -1,23 +1,80 @@
 -- Simple filesystem API with multiple mount points
-
+local unicode = unicode or require("unicode")
 local filesystems = {}
 local lib = {}
+local mtab = {name="", children={}, links={}}
+local fstab = {}
 
-local function hasMountPoint(path)
-    for k, v in pairs(filesystems) do
-        local p = v[1]
-        if p == path then -- if is same path
-            return true
+function lib.segments(path)
+    local parts = {}
+    for part in path:gmatch("[^\\/]+") do
+        local current, up = part:find("^%.?%.$")
+        if current then
+            if up == 2 then
+                table.remove(parts)
+            end
+        else
+            table.insert(parts, part)
         end
     end
-    return false
+    return parts
 end
+
+local function hasMountPoint(path)
+    return lib.getNode(path) ~= nil
+end
+
+function lib.canonical(path)
+  local result = table.concat(segments(path), "/")
+  if unicode.sub(path, 1, 1) == "/" then
+    return "/" .. result
+  else
+    return result
+  end
+end
+
+function lib.concat(...)
+  local set = table.pack(...)
+  for index, value in ipairs(set) do
+    checkArg(index, value, "string")
+  end
+  return lib.canonical(table.concat(set, "/"))
+end
+
 
 function lib.mount(path, fs)
     if hasMountPoint(path) then
-		error(path .. " is arleady mounted")
-	end
+        error(path .. " is arleady mounted")
+    end
     table.insert(filesystems, {path, fs})
+end
+
+function lib.findNode(path)
+    local lastPath = ""
+    local lastNode = {}
+    local seg = lib.segments(path)
+    for k, v in pairs(seg) do
+        if v < table.getn(seg) then
+            lastPath = lastPath .. k .. "/"
+        else
+            lastPath = lastPath .. k
+        end
+        local node = lib.getNode(lastPath)
+        if node ~= nil then
+            lastNode = node
+        end
+    end
+    return lastNode
+end
+
+function lib.getNode(mountPath)
+    for k, v in pairs(filesystems) do
+        local p = v[1]
+        if p == mountPath then -- if is same path
+            return p
+        end
+    end
+    return nil
 end
 
 function lib.umount(path)

--- a/init.lua
+++ b/init.lua
@@ -1,7 +1,6 @@
-
-local component = component or require('component')
-local computer = computer or require('computer')
-local unicode = unicode or require('unicode')
+local component = component or require("component")
+local computer = computer or require("computer")
+local unicode = unicode or require("unicode")
 
 local eeprom = component.list("eeprom")()
 

--- a/lib/vram.lua
+++ b/lib/vram.lua
@@ -1,0 +1,41 @@
+-- off-screen memory api using viewports
+-- Please note: VRAM API doesn't work with gamax92's OCEmu due to a wrong implementation of viewports
+
+local lib = {}
+local gpu = component.proxy(component.list("gpu")())
+
+-- Storing methods
+lib.COLOR_MODE = 0x01 -- store as color (more compact)
+lib.CHAR_MODE  = 0x02
+local mode = lib.COLOR_MODE -- best mode (if depth is 8bits)
+
+function lib.getSize() -- size in bytes of the vram
+	local vw, vh = gpu.getViewport()
+	local w, h = gpu.getResolution()
+	return (w * h) - (vw * vh)
+end
+
+-- Used to increase vram but decrease user resolution
+-- or to decrease vram and increase user resolution
+function lib.setViewport(vw, vh)
+	gpu.setViewport(vw, vh)
+end
+
+function lib.storeByte(off, b)
+	local vw, vh = gpu.getViewport()
+	local w, h = gpu.getResolution()
+	local x = off % (w - vw)
+	local y = off / (w - vw)
+	gpu.set(x, y, string.char(b))
+end
+
+function lib.readByte(off, b)
+	local vw, vh = gpu.getViewport()
+	local w, h = gpu.getResolution()
+	local x = off % (w - vw)
+	local y = off / (w - vw)
+	local ch = gpu.get(x, y)
+	return ch
+end
+
+return lib


### PR DESCRIPTION
Most parts of the kernel has  been edited.
A filesystem API has been added and now you can remove the "fs" method (except filesystem api can't read fully the file, but with a few lines of code it can be done)
I also made a nicier kernel panic message with red error color
And the kernel can now correctly handle the init file's errors
I also started a little api called "VRAM" because i was surprised no one even made use of viewport function in opencomputers gpu, even if it's usefull for vram (as said here: https://ocdoc.cil.li/component:gpu?s[]=gpu), this api is not complete but arleady can be used for storing some bytes of data. For me the VRAM should be used for cheap double-buffering because reading/writing binary data to it i slower than using main RAM, even if currently vram implementation only supports reading/writing binary, double-buffering should be in my next pull request.